### PR TITLE
app: basic dependency navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
             <div id="log-container">
                 <div id="line-numbers-idx" class="line-numbers"></div>
                 <div id="line-numbers-pc" class="line-numbers"></div>
+                <div id="dependency-arrows"></div>
                 <div id="formatted-log-lines"></div>
             </div>
             <div id="state-panel" class="state-panel">

--- a/styles.css
+++ b/styles.css
@@ -68,9 +68,21 @@ body {
     color: #444444;
 }
 
+#dependency-arrows {
+    padding-top: 10px;
+    padding-bottom: 10px;
+    line-height: 1.4;
+    text-align: right;
+    user-select: none;
+    min-width: 2em;
+    white-space: pre;
+    height: fit-content;
+
+}
 #formatted-log-lines {
     border: 1px solid #ccc;
     border-radius: 0 4px 4px 0;
+    border-left: none;
     background: white;
     padding: 10px;
     line-height: 1.4;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES6",
+        "target": "ES2020",
         "module": "ESNext",
         "moduleResolution": "node",
         "resolveJsonModule": true,


### PR DESCRIPTION
When highlighting data dependencies upstream instructions may be "far away" withing the instruction stream. In such cases the user would have to scroll for a while and not miss the dependency while doing so. Also, there was no visual indicator that there even is a dependency, if it's not immediately visible.

Implement a "dependency-arrows" column in the log view, imeediately to the left of the instructions stream. It's ASCII-based lines between collected upstream dependencies of the selected line. For example:

  ┌─ r1 = *(u64 *)(r0 -8)
  │  r2 = 0xff6f3b1a00e97010
  └─ *(u64 *)(r2 +8) = r1

The vertical lines are interactive: if one of the closest anchored lines is not visible, it changes to an arrow on hover, and scrolls to the closes relevant line on click.

The lines are updated on each updateView() and are visible only if there is a selected mem slot with known dependencies. Navigation targets are computed on hover at "dependency-arrows" column.

The memSlotDependencies field of the state is now stored as a sorted array of indices, and not as a Set. This is useful when computing navigation targets.

Closes: https://github.com/libbpf/bpfvv/issues/10