### PR TITLE
app: fix getVisibleIdxRange

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -789,7 +789,7 @@ const createApp = (url: string) => {
         const linesRect = logLines.getBoundingClientRect();
         const containerRect = logContainer.getBoundingClientRect();
 
-        if (containerRect.height * 2 > linesRect.height) {
+        if (containerRect.height > linesRect.height) {
             return [0, state.lines.length - 1];
         }
 


### PR DESCRIPTION
Fix a bug when we double the log-container height when calculating the visible range. This is an artifact of previous implementation where the range was calculated only for updateView.