### PR TITLE
app: don't show independent writes

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -238,10 +238,15 @@ const createApp = (url: string) => {
         memSlotDependencies: [],
     };
 
+    const isVoidHelperArg = (arg) : boolean => {
+        return arg.type === 'void' && arg.name == null && arg.star == null;
+    }
+
     const buildBpfHelpersMap = async () : Promise<Map<string, any>> => {
         const map = new Map();
         for (const helper of BPF_HELPERS_JSON.helpers) {
-            map.set(helper.name, helper.args)
+            helper.args = helper.args.filter(arg => !isVoidHelperArg(arg));
+            map.set(helper.name, helper.args);
         }
         return map;
     }

--- a/app.ts
+++ b/app.ts
@@ -822,7 +822,9 @@ const createApp = (url: string) => {
         const minAnchor = Math.min(...anchors);
         const divs = dependencyArrows.children;
 
-        if (!state.selectedMemSlotId) {
+        if (!state.selectedMemSlotId
+            || anchors.length === 0
+            || minAnchor === maxAnchor) {
             for (let idx = minIdx; idx <= maxIdx; idx++) {
                 divs[idx].textContent = '\n';
             }


### PR DESCRIPTION
When collecting dependencies for a mem slot, so far the app always
showed the chain of "last known writes". So, for example:

  11: r1 = 1
  ...
  17: r1 = 2

By clicking on r1 at line 17 the line 11 would be highlighted. This is
not a real dependency and not particularly useful.

Rewrite collectMemSlotDependencies routine to more intuitive
implementation using a recursive helper `memSlotDependencies`. The
helper takes line idx and slot id and then looks at the instruction at
last known write and its effect to determine whether it's appropriate
to traverse further.

The design hasn't changed: dependency highlighting stops at the first
instruction with multiple slots read, with the exception of a selected
mem slot update.
