### PR TITLE
Implement C source lines handling with inline highlighting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { VerifierLogState, processRawLines } from "./analyzer";
+import { CSourceMap, VerifierLogState, processRawLines } from "./analyzer";
 
 import {
   fetchLogFromUrl,
@@ -73,6 +73,7 @@ function App() {
   const [verifierLogState, setVerifierLogState] = useState<VerifierLogState>({
     lines: [],
     bpfStates: [],
+    cSourceMap: new CSourceMap(),
   });
   const [hoveredState, setHoveredState] = useState<LogLineState>({
     memSlotId: "",
@@ -112,7 +113,11 @@ function App() {
   }, [setSelectedLineScroll, verifierLogState]);
 
   const onClear = useCallback(() => {
-    setVerifierLogState({ lines: [], bpfStates: [] });
+    setVerifierLogState({
+      lines: [],
+      bpfStates: [],
+      cSourceMap: new CSourceMap(),
+    });
     setSelectedState({ line: 0, memSlotId: "" });
     const fiCurrent = fileInputRef.current;
     if (fiCurrent) {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -233,8 +233,7 @@ export function getMemSlotDependencies(
 ): Set<number> {
   const { lines, bpfStates } = verifierLogState;
   let deps = new Set<number>();
-  const ins = lines[selectedLine].bpfIns;
-  if (!ins) return deps;
+  if (lines[selectedLine].type !== ParsedLineType.INSTRUCTION) return deps;
 
   const bpfState = bpfStates[selectedLine];
   if (!bpfState) return deps;
@@ -245,9 +244,8 @@ export function getMemSlotDependencies(
   if (!bpfState.lastKnownWrites.has(memSlotId)) return deps;
 
   const depIdx = bpfState.lastKnownWrites.get(memSlotId);
-  if (!depIdx) return deps;
+  if (!depIdx || lines[depIdx].type !== ParsedLineType.INSTRUCTION) return deps;
   const depIns = lines[depIdx].bpfIns;
-  if (!depIns) return deps;
 
   const nReads = depIns?.reads?.length;
 

--- a/src/components.test.tsx
+++ b/src/components.test.tsx
@@ -19,6 +19,8 @@ import {
   BpfJmpInstruction,
   BpfExitInstruction,
   BpfGotoJmpInstruction,
+  parseLine,
+  InstructionLine,
 } from "./parser";
 
 function createOp(
@@ -40,7 +42,7 @@ function createOp(
 
 describe("MemSlot", () => {
   function createParsedLine(raw: string, idx: number): ParsedLine {
-    return { raw, idx, type: ParsedLineType.INSTRUCTION };
+    return parseLine(raw, idx);
   }
 
   it("renders raw line when op is undefined", () => {
@@ -153,11 +155,12 @@ describe("JmpInstruction", () => {
     };
   }
 
-  function createLine(bpfIns: BpfJmpInstruction): ParsedLine {
+  function createLine(bpfIns: BpfJmpInstruction): InstructionLine {
     return {
       raw: "",
       idx: 0,
       bpfIns,
+      bpfStateExprs: [],
       type: ParsedLineType.INSTRUCTION,
     };
   }

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -299,6 +299,10 @@ const LogLineRaw = ({
       topClasses.push("normal-line");
       content = InstructionLineContent({ line, frame });
       break;
+    case ParsedLineType.C_SOURCE:
+      topClasses.push("inline-c-source-line");
+      content = <>{line.raw}</>;
+      break;
     default:
       topClasses.push("ignorable-line");
       content = <>{line.raw}</>;
@@ -790,6 +794,14 @@ export function MainContent({
         selectedMemSlotIdEl.classList.add("selected-mem-slot");
       }
 
+      const relevantCLineIds: Set<string> = new Set();
+      for (const idx of [selectedLine, ...memSlotDependencies]) {
+        const cLineId = verifierLogState.cSourceMap.logLineToCLine.get(idx);
+        if (cLineId) {
+          relevantCLineIds.add(cLineId);
+        }
+      }
+
       verifierLogState.lines.forEach((line) => {
         const idx = line.idx;
         if (selectedLine === idx) {
@@ -797,7 +809,10 @@ export function MainContent({
         }
         if (
           line.type === ParsedLineType.UNRECOGNIZED ||
-          !memSlotDependencies.includes(idx)
+          (line.type === ParsedLineType.INSTRUCTION &&
+            !memSlotDependencies.includes(idx)) ||
+          (line.type === ParsedLineType.C_SOURCE &&
+            !relevantCLineIds.has(line.id))
         ) {
           return;
         }

--- a/src/index.css
+++ b/src/index.css
@@ -130,13 +130,20 @@ body {
   color: #cccccc;
 }
 
+.inline-c-source-line,
+.active_mem_slot .inline-c-source-line.selected-line,
+.active_mem_slot .inline-c-source-line.dependency-line {
+  color: blue;
+}
+
 .selected-line,
 .ignorable-line.selected-line {
   background-color: #ccccff;
   color: #000;
 }
 
-.active_mem_slot .normal-line {
+.active_mem_slot .normal-line,
+.active_mem_slot .inline-c-source-line {
   color: #888888;
 }
 

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -140,8 +140,9 @@ describe("parser", () => {
       idx: 5,
       raw: CSourceLineSample,
       content: "n->key = 3;",
-      filename: "rbtree.c",
-      line: 201,
+      fileName: "rbtree.c",
+      lineNum: 201,
+      id: "rbtree.c:201",
     });
   });
 });

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -22,6 +22,7 @@ const AddrSpaceCastSample =
   "2976: (bf) r1 = addr_space_cast(r7, 0, 1)     ; frame1: R1_w=arena";
 const ConditionalPseudoMayGotoSample = "2984: (e5) may_goto pc+3";
 const ConditionalPseudoGotoOrNopSample = "2984: (e5) goto_or_nop pc+3";
+const CSourceLineSample = "; n->key = 3; @ rbtree.c:201";
 
 function expectBpfIns(line: ParsedLine): BpfInstruction {
   expect(line.type).toBe(ParsedLineType.INSTRUCTION);
@@ -130,5 +131,17 @@ describe("parser", () => {
     const ins = expectBpfJmpOrNopInstruction(parsed);
     expect(ins.target).toBe("pc+3");
     expect(ins.opcode.code).toBe(BpfJmpCode.JCOND);
+  });
+
+  it("parses C source line matching RE_C_SOURCE_LINE regex", () => {
+    const parsed = parseLine(CSourceLineSample, 5);
+    expect(parsed).toEqual({
+      type: ParsedLineType.C_SOURCE,
+      idx: 5,
+      raw: CSourceLineSample,
+      content: "n->key = 3;",
+      filename: "rbtree.c",
+      line: 201,
+    });
   });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -212,8 +212,9 @@ export type InstructionLine = {
 export type CSourceLine = {
   type: ParsedLineType.C_SOURCE;
   content: string;
-  filename: string;
-  line: number;
+  fileName: string;
+  lineNum: number;
+  id: string;
 } & GenericParsedLine;
 
 export type ParsedLine = UnrecognizedLine | InstructionLine | CSourceLine;
@@ -767,13 +768,16 @@ function parseOpcodeIns(str: string, pc: number): BpfInstructionPair {
 function parseCSourceLine(str: string, idx: number): CSourceLine | null {
   const { match } = consumeRegex(RE_C_SOURCE_LINE, str);
   if (!match) return null;
+  const fileName = match[2];
+  const lineNum = parseInt(match[3], 10);
   return {
     type: ParsedLineType.C_SOURCE,
     idx,
     raw: str,
     content: match[1],
-    filename: match[2],
-    line: parseInt(match[3], 10),
+    fileName,
+    lineNum,
+    id: `${fileName}:${lineNum}`,
   };
 }
 


### PR DESCRIPTION
Implement parsing the log lines with C source code, and building a `CSourceMap` from them to associate instruction lines with them. Add basic highlighting of the C source lines within the main log view.

Other changes in this PR:
- Remove confusing "MEM" entires from the state panel
- Introduce proper subtypes of `ParsedLine`

Part of #4 