### PR TITLE
Add C Source Line View

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,6 +47,6 @@ export default [
     },
   },
   {
-    ignores: ['node_modules/**', 'dist/**', 'coverage/**'],
+    ignores: ['node_modules/**', 'dist/**', 'coverage/**', 'src/__snapshots__/**'],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "serve": "vite preview",
     "test": "jest",
     "format": "prettier src/* --write",
-    "lint": "eslint src/*",
+    "lint": "eslint",
     "typecheck": "tsc --noEmit"
   },
   "eslintConfig": {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,50 +4,22 @@
 import "@testing-library/jest-dom";
 import { render, createEvent, fireEvent } from "@testing-library/react";
 import App from "./App";
+import { SAMPLE_LOG_DATA_1, SAMPLE_LOG_DATA_2 } from "./test-data";
+
+const DOM_EL_FAIL = "DOM Element missing";
 
 describe("App", () => {
-  it("does not throw", () => {
-    render(<App />);
-
-    const inputEl = document.getElementById("input-text");
-    expect(inputEl).toBeTruthy();
-    expect(inputEl).toBeVisible();
-  });
-
   it("renders the correct starting elements", () => {
-    render(<App />);
-
-    const exampleLinkEl = document.getElementById("example-link");
-    expect(exampleLinkEl?.innerHTML).toBe("Load an example log");
-
-    const inputEl = document.getElementById("input-text");
-    expect(inputEl?.getAttribute("placeholder")).toBe(
-      "Paste a verifier log here or choose a file",
-    );
-    expect(inputEl?.tagName).toBe("TEXTAREA");
-
-    const fileInputEl = document.getElementById("file-input");
-    expect(fileInputEl?.tagName).toBe("INPUT");
-
-    const gotoLineEl = document.getElementById("goto-line-input");
-    expect(gotoLineEl?.tagName).toBe("INPUT");
-
-    const gotoStartEl = document.getElementById("goto-start");
-    expect(gotoStartEl?.tagName).toBe("BUTTON");
-
-    const gotoEndEl = document.getElementById("goto-end");
-    expect(gotoEndEl?.tagName).toBe("BUTTON");
-
-    const clearEl = document.getElementById("clear");
-    expect(clearEl?.tagName).toBe("BUTTON");
+    const { container } = render(<App />);
+    expect(container).toMatchSnapshot();
   });
 
   it("renders the log visualizer when text is pasted", async () => {
-    render(<App />);
+    const { container, rerender } = render(<App />);
 
     const inputEl = document.getElementById("input-text");
     if (!inputEl) {
-      fail();
+      throw new Error(DOM_EL_FAIL);
     }
 
     fireEvent(
@@ -60,51 +32,26 @@ describe("App", () => {
       }),
     );
 
-    const logContainerEl = document.getElementById("log-container");
-    expect(logContainerEl).toBeTruthy();
-    expect(logContainerEl).toBeVisible();
+    rerender(<App />);
+    expect(container).toMatchSnapshot();
 
-    const logLinesEl = document.getElementById("line-numbers-idx");
-    expect(logLinesEl?.innerHTML).toBe(
-      '<div class="line-numbers-line">1</div>',
-    );
-
-    const logLinesPcEl = document.getElementById("line-numbers-pc");
-    expect(logLinesPcEl?.innerHTML).toBe(
-      '<div class="line-numbers-line">314:</div>',
-    );
-
+    expect(document.getElementById("c-source-container")).toBeTruthy();
     expect(document.getElementById("formatted-log-lines")).toBeTruthy();
-
-    const firstLine = document.getElementById("line-0");
-    expect(firstLine?.innerHTML).toBe(
-      '*(u8 *)(<span id="mem-slot-r7-line-0" class="mem-slot r7" data-id="r7">r7</span> +1303)&nbsp;=&nbsp;<span id="mem-slot-r1-line-0" class="mem-slot r1" data-id="r1">r1</span>',
-    );
-
-    const hintSelectedLineEl = document.getElementById("hint-selected-line");
-    expect(hintSelectedLineEl?.innerHTML).toBe(
-      "<span>[selected raw line] 1:</span>&nbsp;314: (73) *(u8 *)(r7 +1303) = r1      ; frame1: R1_w=0 R7=map_value(off=0,ks=4,vs=2808,imm=0)",
-    );
-
-    expect(document.getElementById("state-panel-shown")).toBeTruthy();
-
-    const statePanelHeader = document.getElementById("state-panel-header");
-    expect(statePanelHeader?.innerHTML).toBe(
-      "<div>Line: 1</div><div>PC: 314</div><div>Frame: 0</div>",
-    );
-
-    //TODO: add tests for state panel content
+    expect(document.getElementById("state-panel")).toBeTruthy();
 
     // Hit the clear button and make sure we go back to the intial state
     const clearEl = document.getElementById("clear");
     if (!clearEl) {
-      fail();
+      throw new Error(DOM_EL_FAIL);
     }
     fireEvent(clearEl, createEvent.click(clearEl));
-    expect(document.getElementById("log-container")).toBeFalsy();
-    expect(document.getElementById("state-panel-shown")).toBeFalsy();
-    expect(document.getElementById("input-text")).toBeTruthy();
-    expect(document.getElementById("input-text")).toBeVisible();
+
+    rerender(<App />);
+    expect(container).toMatchSnapshot();
+
+    expect(document.getElementById("c-source-container")).toBeFalsy();
+    expect(document.getElementById("formatted-log-lines")).toBeFalsy();
+    expect(document.getElementById("state-panel")).toBeFalsy();
   });
 
   it("jumps to the next/prev instruction on key up/down", async () => {
@@ -112,38 +59,33 @@ describe("App", () => {
 
     const inputEl = document.getElementById("input-text");
     if (!inputEl) {
-      fail();
+      throw new Error(DOM_EL_FAIL);
     }
 
     fireEvent(
       inputEl,
       createEvent.paste(inputEl, {
         clipboardData: {
-          getData: () =>
-            `
-          0: (18) r1 = 0x11                     ; R1_w=17
-2: (b7) r2 = 0                        ; R2_w=0
-3: (85) call bpf_obj_new_impl#54651   ; R0_w=ptr_or_null_node_data(id=2,ref_obj_id=2) refs=2
-4: (bf) r6 = r0                       ; R0_w=ptr_or_null_node_data(id=2,ref_obj_id=2) R6_w=ptr_or_null_node_data(id=2,ref_obj_id=2) refs=2
-5: (b7) r7 = 1                        ; R7_w=1 refs=2
-; if (!n) @ rbtree.c:199
-6: (15) if r6 == 0x0 goto pc+104      ; R6_w=ptr_node_data(ref_obj_id=2) refs=2
-7: (b7) r1 = 4                        ; R1_w=4 ref
-            `,
+          getData: () => SAMPLE_LOG_DATA_1,
         },
       }),
     );
 
+    // Need to show all log lines
+    const checkboxEl = document.getElementById("show-full-log");
+    if (!checkboxEl) {
+      throw new Error(DOM_EL_FAIL);
+    }
+    fireEvent(checkboxEl, createEvent.click(checkboxEl));
+
     const logContainerEl = document.getElementById("log-container");
-    expect(logContainerEl).toBeTruthy();
-    expect(logContainerEl).toBeVisible();
 
     const line5 = document.getElementById("line-5");
     const line6 = document.getElementById("line-6");
     const line7 = document.getElementById("line-7");
 
-    if (!line5 || !line6 || !line7 || !logContainerEl) {
-      fail();
+    if (!line5 || !line7 || !line6 || !logContainerEl) {
+      throw new Error(DOM_EL_FAIL);
     }
 
     expect(line5.innerHTML).toBe(
@@ -173,5 +115,111 @@ describe("App", () => {
     expect(line5.classList.contains("selected-line")).toBeTruthy();
     expect(line6.classList.contains("selected-line")).toBeFalsy();
     expect(line7.classList.contains("selected-line")).toBeFalsy();
+  });
+
+  it("c lines and state panel containers are collapsible", async () => {
+    render(<App />);
+
+    const inputEl = document.getElementById("input-text");
+    if (!inputEl) {
+      throw new Error("Input text is missing");
+    }
+
+    fireEvent(
+      inputEl,
+      createEvent.paste(inputEl, {
+        clipboardData: {
+          getData: () => SAMPLE_LOG_DATA_1,
+        },
+      }),
+    );
+
+    const cSourceEl = document.getElementById("c-source-container");
+    const cSourceFile = cSourceEl?.querySelector(".c-source-file");
+
+    expect(cSourceFile).toBeVisible();
+
+    const cSourceHideShow = cSourceEl?.querySelector(".hide-show-button");
+
+    if (!cSourceHideShow) {
+      throw new Error(DOM_EL_FAIL);
+    }
+
+    fireEvent(cSourceHideShow, createEvent.click(cSourceHideShow));
+    expect(cSourceFile).not.toBeVisible();
+
+    const statePanelEl = document.getElementById("state-panel");
+    const statePanelHeader = document.getElementById("state-panel-header");
+
+    expect(statePanelHeader).toBeVisible();
+
+    const statePanelHideShow = statePanelEl?.querySelector(".hide-show-button");
+
+    if (!statePanelHideShow) {
+      throw new Error(DOM_EL_FAIL);
+    }
+
+    fireEvent(statePanelHideShow, createEvent.click(statePanelHideShow));
+    expect(statePanelHeader).not.toBeVisible();
+  });
+
+  it("highlights the associated c source or log line(s) when the other is clicked ", async () => {
+    render(<App />);
+
+    const inputEl = document.getElementById("input-text");
+    if (!inputEl) {
+      throw new Error(DOM_EL_FAIL);
+    }
+
+    fireEvent(
+      inputEl,
+      createEvent.paste(inputEl, {
+        clipboardData: {
+          getData: () => SAMPLE_LOG_DATA_2,
+        },
+      }),
+    );
+
+    const line4El = document.getElementById("line-4");
+    const cLineEl = document.getElementById("line-rbtree.c:198");
+    if (!line4El || !cLineEl) {
+      throw new Error(DOM_EL_FAIL);
+    }
+
+    expect(line4El.classList).not.toContain("selected-line");
+    expect(cLineEl.classList).not.toContain("selected-line");
+
+    // Click on the first instruction log line
+    fireEvent(line4El, createEvent.click(line4El));
+
+    expect(line4El.classList).toContain("selected-line");
+    expect(cLineEl.classList).toContain("selected-line");
+
+    // Click on another log line
+    const line10El = document.getElementById("line-10");
+    if (!line10El) {
+      throw new Error(DOM_EL_FAIL);
+    }
+
+    fireEvent(line10El, createEvent.click(line10El));
+
+    expect(line4El.classList).not.toContain("selected-line");
+    expect(cLineEl.classList).not.toContain("selected-line");
+
+    // Click on the first c source line
+    fireEvent(cLineEl, createEvent.click(cLineEl));
+
+    expect(line4El.classList).toContain("selected-line");
+    expect(cLineEl.classList).toContain("selected-line");
+
+    // The other instructions for this source line should also be selected
+    const followingIns = ["line-5", "line-6", "line-7", "line-8"];
+    followingIns.forEach((lineId) => {
+      const el = document.getElementById(lineId);
+      if (!el) {
+        throw new Error(DOM_EL_FAIL);
+      }
+      expect(el.classList).toContain("selected-line");
+    });
   });
 });

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -1,0 +1,508 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`App renders the correct starting elements 1`] = `
+<div>
+  <div
+    class="App"
+  >
+    <div
+      class="container"
+    >
+      <div
+        class="navigation-panel"
+      >
+        <h1>
+          BPF Verifier Visualizer
+        </h1>
+        <div
+          class="line-nav-item"
+          id="load-status"
+        >
+          (
+          0
+           lines)
+        </div>
+        <button
+          class="line-nav-item"
+          id="goto-start"
+        >
+          Start
+        </button>
+        <button
+          class="line-nav-item"
+          id="goto-end"
+        >
+          End
+        </button>
+        <button
+          class="line-nav-item"
+          id="clear"
+        >
+          Clear
+        </button>
+        <label>
+          <input
+            id="show-full-log"
+            type="checkbox"
+          />
+          Show Full Log
+        </label>
+        <div
+          class="file-input-container"
+        >
+          <input
+            id="file-input"
+            type="file"
+          />
+        </div>
+        <a
+          href="/?url=https://gist.githubusercontent.com/theihor/e0002c119414e6b40e2192bd7ced01b1/raw/866bcc155c2ce848dcd4bc7fd043a97f39a2d370/gistfile1.txt"
+          id="example-link"
+        >
+          Load an example log
+        </a>
+        <a
+          class="howto-link"
+          href="https://github.com/theihor/bpfvv/blob/master/HOWTO.md"
+          rel="noreferrer"
+          target="_blank"
+        >
+          How To Use
+        </a>
+      </div>
+      <textarea
+        id="input-text"
+        placeholder="Paste a verifier log here or choose a file"
+      />
+      <div
+        id="hint"
+      >
+        <div
+          class="hint-line"
+          id="hint-hovered-line"
+        >
+          <br />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`App renders the log visualizer when text is pasted 1`] = `
+<div>
+  <div
+    class="App"
+  >
+    <div
+      class="container"
+    >
+      <div
+        class="navigation-panel"
+      >
+        <h1>
+          BPF Verifier Visualizer
+        </h1>
+        <div
+          class="line-nav-item"
+          id="load-status"
+        >
+          (
+          1
+           lines)
+        </div>
+        <button
+          class="line-nav-item"
+          id="goto-start"
+        >
+          Start
+        </button>
+        <button
+          class="line-nav-item"
+          id="goto-end"
+        >
+          End
+        </button>
+        <button
+          class="line-nav-item"
+          id="clear"
+        >
+          Clear
+        </button>
+        <label>
+          <input
+            id="show-full-log"
+            type="checkbox"
+          />
+          Show Full Log
+        </label>
+        <div
+          class="file-input-container"
+        >
+          <input
+            id="file-input"
+            type="file"
+          />
+        </div>
+        <a
+          href="/?url=https://gist.githubusercontent.com/theihor/e0002c119414e6b40e2192bd7ced01b1/raw/866bcc155c2ce848dcd4bc7fd043a97f39a2d370/gistfile1.txt"
+          id="example-link"
+        >
+          Load an example log
+        </a>
+        <a
+          class="howto-link"
+          href="https://github.com/theihor/bpfvv/blob/master/HOWTO.md"
+          rel="noreferrer"
+          target="_blank"
+        >
+          How To Use
+        </a>
+      </div>
+      <div
+        class="main-content"
+        id="main-content"
+      >
+        <div
+          class="c-source-panel"
+          id="c-source-container"
+        >
+          <div
+            class="hide-show-button left"
+          >
+            ⇐
+            <div
+              class="hide-show-tooltip"
+            >
+              Hide
+               
+              C source lines
+            </div>
+          </div>
+        </div>
+        <div
+          class=""
+          id="log-container"
+        >
+          <div
+            class="line-numbers"
+            id="line-numbers-pc"
+          >
+            <div
+              class="line-numbers-line"
+            >
+              314:
+            </div>
+          </div>
+          <div
+            id="dependency-arrows"
+          >
+            <div
+              class="dep-arrow"
+              id="dep-arrow-line-0"
+              line-index="0"
+            />
+          </div>
+          <div
+            id="formatted-log-lines"
+          >
+            <div
+              class="log-line normal-line selected-line"
+              id="line-0"
+              line-index="0"
+            >
+              *(u8 *)(
+              <span
+                class="mem-slot r7"
+                data-id="r7"
+                id="mem-slot-r7-line-0"
+              >
+                r7
+              </span>
+               +1303)
+               
+              =
+               
+              <span
+                class="mem-slot r1"
+                data-id="r1"
+                id="mem-slot-r1-line-0"
+              >
+                r1
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="state-panel"
+          id="state-panel"
+        >
+          <div
+            id="state-panel-header"
+          >
+            <div>
+              Log Line: 
+              1
+            </div>
+            <div>
+              C Line: 
+              0
+            </div>
+            <div>
+              PC: 
+              314
+            </div>
+            <div>
+              Frame: 
+              0
+            </div>
+          </div>
+          <div
+            class="hide-show-button right"
+          >
+            ⇒
+            <div
+              class="hide-show-tooltip"
+            >
+              Hide
+               
+              state panel
+            </div>
+          </div>
+          <table>
+            <tbody>
+              <tr
+                class=""
+              >
+                <td>
+                  r0
+                </td>
+                <td>
+                  <span />
+                </td>
+              </tr>
+              <tr
+                class="effect-read"
+              >
+                <td>
+                  r1
+                </td>
+                <td>
+                  <span>
+                    0
+                  </span>
+                </td>
+              </tr>
+              <tr
+                class=""
+              >
+                <td>
+                  r2
+                </td>
+                <td>
+                  <span />
+                </td>
+              </tr>
+              <tr
+                class=""
+              >
+                <td>
+                  r3
+                </td>
+                <td>
+                  <span />
+                </td>
+              </tr>
+              <tr
+                class=""
+              >
+                <td>
+                  r4
+                </td>
+                <td>
+                  <span />
+                </td>
+              </tr>
+              <tr
+                class=""
+              >
+                <td>
+                  r5
+                </td>
+                <td>
+                  <span />
+                </td>
+              </tr>
+              <tr
+                class=""
+              >
+                <td>
+                  r6
+                </td>
+                <td>
+                  <span />
+                </td>
+              </tr>
+              <tr
+                class="effect-read"
+              >
+                <td>
+                  r7
+                </td>
+                <td>
+                  <span>
+                    map_value(off=0,ks=4,vs=2808,imm=0)
+                  </span>
+                </td>
+              </tr>
+              <tr
+                class=""
+              >
+                <td>
+                  r8
+                </td>
+                <td>
+                  <span />
+                </td>
+              </tr>
+              <tr
+                class=""
+              >
+                <td>
+                  r9
+                </td>
+                <td>
+                  <span />
+                </td>
+              </tr>
+              <tr
+                class=""
+              >
+                <td>
+                  r10
+                </td>
+                <td>
+                  <span>
+                    fp-0
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div
+        id="hint"
+      >
+        <div
+          class="hint-line"
+          id="hint-selected-line"
+        >
+          <span>
+            [selected raw line] 
+            1
+            :
+          </span>
+           
+          314: (73) *(u8 *)(r7 +1303) = r1      ; frame1: R1_w=0 R7=map_value(off=0,ks=4,vs=2808,imm=0)
+        </div>
+        <div
+          class="hint-line"
+          id="hint-hovered-line"
+        >
+          <br />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`App renders the log visualizer when text is pasted 2`] = `
+<div>
+  <div
+    class="App"
+  >
+    <div
+      class="container"
+    >
+      <div
+        class="navigation-panel"
+      >
+        <h1>
+          BPF Verifier Visualizer
+        </h1>
+        <div
+          class="line-nav-item"
+          id="load-status"
+        >
+          (
+          0
+           lines)
+        </div>
+        <button
+          class="line-nav-item"
+          id="goto-start"
+        >
+          Start
+        </button>
+        <button
+          class="line-nav-item"
+          id="goto-end"
+        >
+          End
+        </button>
+        <button
+          class="line-nav-item"
+          id="clear"
+        >
+          Clear
+        </button>
+        <label>
+          <input
+            id="show-full-log"
+            type="checkbox"
+          />
+          Show Full Log
+        </label>
+        <div
+          class="file-input-container"
+        >
+          <input
+            id="file-input"
+            type="file"
+          />
+        </div>
+        <a
+          href="/?url=https://gist.githubusercontent.com/theihor/e0002c119414e6b40e2192bd7ced01b1/raw/866bcc155c2ce848dcd4bc7fd043a97f39a2d370/gistfile1.txt"
+          id="example-link"
+        >
+          Load an example log
+        </a>
+        <a
+          class="howto-link"
+          href="https://github.com/theihor/bpfvv/blob/master/HOWTO.md"
+          rel="noreferrer"
+          target="_blank"
+        >
+          How To Use
+        </a>
+      </div>
+      <textarea
+        id="input-text"
+        placeholder="Paste a verifier log here or choose a file"
+      />
+      <div
+        id="hint"
+      >
+        <div
+          class="hint-line"
+          id="hint-hovered-line"
+        >
+          <br />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/index.css
+++ b/src/index.css
@@ -24,7 +24,6 @@ h1 {
 .main-content {
   display: flex;
   flex: 1;
-  gap: 10px;
   min-height: 0; /* Important for flex child to respect parent height */
   font-family: monospace;
   font-size: 14px;
@@ -82,6 +81,47 @@ h1 {
   text-decoration: underline;
 }
 
+/* C Source Lines */
+
+#c-source-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  gap: 0;
+  overflow: auto;
+}
+
+.c-source-panel {
+  position: relative;
+  border-right: 2px solid #ccc;
+}
+
+.c-source-file {
+  width: 100%;
+}
+
+.filename-header {
+  background-color: #d4d4d4;
+  height: 20px;
+  font-weight: bold;
+  width: 100%;
+  padding: 10px 0px 10px 10px;
+}
+
+.file-lines {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  min-width: 0;
+  gap: 0;
+  overflow: auto;
+}
+
+.source-lines {
+  color: #0f04c6;
+}
+
 /* Log Lines */
 
 #log-container {
@@ -110,7 +150,8 @@ h1 {
   color: #444444;
 }
 
-#formatted-log-lines {
+#formatted-log-lines,
+.source-lines {
   background: white;
   padding: 10px;
   line-height: 1.4;
@@ -124,7 +165,7 @@ h1 {
 }
 
 .mem-slot:hover {
-  background-color: #ccccff;
+  background-color: #d4d4d4;
 }
 
 .register-panel {
@@ -148,7 +189,8 @@ h1 {
 }
 
 .selected-line,
-.ignorable-line.selected-line {
+.ignorable-line.selected-line,
+.dependency-line.selected-line {
   background-color: #ccccff;
   color: #000;
 }
@@ -170,7 +212,8 @@ h1 {
 
 .line-numbers-line,
 .dep-arrow,
-.log-line {
+.log-line,
+.c-source-line {
   height: 20px;
 }
 
@@ -186,8 +229,12 @@ h1 {
 }
 
 .log-line:hover {
-  background-color: #eeeeff;
+  background-color: #eeeeee;
   color: #000;
+}
+
+.log-line.selected-line:hover {
+  background-color: #ccccff;
 }
 
 .dependency-line {
@@ -289,17 +336,17 @@ h1 {
 
 .state-panel {
   background-color: #f8f8f8;
-  border-left: 1px solid #ccc;
+  border-left: 2px solid #ccc;
   position: relative;
 }
 
-#state-panel-shown {
+#state-panel {
   flex: 1;
   padding: 10px;
   overflow: auto;
 }
 
-#state-panel-collapsed {
+.panel-hidden {
   flex: none;
   width: 30px;
   padding: 10px;
@@ -353,9 +400,9 @@ h1 {
   font-size: 30px;
   font-weight: normal;
   top: 0px;
-  right: 15px;
   text-align: center;
   cursor: pointer;
+  right: 15px;
 }
 
 .hide-show-button:hover {
@@ -373,7 +420,6 @@ h1 {
 .hide-show-tooltip {
   position: absolute;
   top: 6px;
-  right: 30px;
   width: 160px;
   font-size: 12px;
   background-color: #f8f8f8;
@@ -381,6 +427,12 @@ h1 {
   border: 1px solid #ccc;
   color: #000;
   box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+  right: 30px;
+}
+
+.hide-show-button.hidden.left .hide-show-tooltip {
+  right: auto;
+  left: 30px;
 }
 
 /* Footer */

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -765,6 +765,10 @@ function parseOpcodeIns(str: string, pc: number): BpfInstructionPair {
   return { ins: undefined, rest: str };
 }
 
+export function getCLineId(fileName: string, lineNum: number): string {
+  return `${fileName}:${lineNum}`;
+}
+
 function parseCSourceLine(str: string, idx: number): CSourceLine | null {
   const { match } = consumeRegex(RE_C_SOURCE_LINE, str);
   if (!match) return null;
@@ -777,7 +781,7 @@ function parseCSourceLine(str: string, idx: number): CSourceLine | null {
     content: match[1],
     fileName,
     lineNum,
-    id: `${fileName}:${lineNum}`,
+    id: getCLineId(fileName, lineNum),
   };
 }
 

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -1,0 +1,133 @@
+export const SAMPLE_LOG_DATA_1 = `
+          0: (18) r1 = 0x11                     ; R1_w=17
+2: (b7) r2 = 0                        ; R2_w=0
+3: (85) call bpf_obj_new_impl#54651   ; R0_w=ptr_or_null_node_data(id=2,ref_obj_id=2) refs=2
+4: (bf) r6 = r0                       ; R0_w=ptr_or_null_node_data(id=2,ref_obj_id=2) R6_w=ptr_or_null_node_data(id=2,ref_obj_id=2) refs=2
+5: (b7) r7 = 1                        ; R7_w=1 refs=2
+; if (!n) @ rbtree.c:199
+6: (15) if r6 == 0x0 goto pc+104      ; R6_w=ptr_node_data(ref_obj_id=2) refs=2
+7: (b7) r1 = 4                        ; R1_w=4 ref
+            `;
+
+export const SAMPLE_LOG_DATA_2 = `PROCESSING rbtree.bpf.o/rbtree_first_and_remove, DURATION US: 842, VERDICT: failure, VERIFIER LOG:
+arg#0 reference type('UNKNOWN ') size cannot be determined: -22
+0: R1=ctx() R10=fp0
+; n = bpf_obj_new(typeof(*n)); @ rbtree.c:198
+0: (18) r1 = 0x11                     ; R1_w=17
+2: (b7) r2 = 0                        ; R2_w=0
+3: (85) call bpf_obj_new_impl#54651   ; R0_w=ptr_or_null_node_data(id=2,ref_obj_id=2) refs=2
+4: (bf) r6 = r0                       ; R0_w=ptr_or_null_node_data(id=2,ref_obj_id=2) R6_w=ptr_or_null_node_data(id=2,ref_obj_id=2) refs=2
+5: (b7) r7 = 1                        ; R7_w=1 refs=2
+; if (!n) @ rbtree.c:199
+6: (15) if r6 == 0x0 goto pc+104      ; R6_w=ptr_node_data(ref_obj_id=2) refs=2
+7: (b7) r1 = 4                        ; R1_w=4 refs=2
+; n->data = 4; @ rbtree.c:202
+8: (7b) *(u64 *)(r6 +8) = r1          ; R1_w=4 R6_w=ptr_node_data(ref_obj_id=2) refs=2
+9: (b7) r1 = 3                        ; R1_w=3 refs=2
+; n->key = 3; @ rbtree.c:201
+10: (7b) *(u64 *)(r6 +0) = r1         ; R1_w=3 R6_w=ptr_node_data(ref_obj_id=2) refs=2
+; m = bpf_obj_new(typeof(*m)); @ rbtree.c:204
+11: (18) r1 = 0x11                    ; R1_w=17 refs=2
+13: (b7) r2 = 0                       ; R2_w=0 refs=2
+14: (85) call bpf_obj_new_impl#54651          ; R0=ptr_or_null_node_data(id=4,ref_obj_id=4) refs=2,4
+15: (bf) r8 = r0                      ; R0=ptr_or_null_node_data(id=4,ref_obj_id=4) R8_w=ptr_or_null_node_data(id=4,ref_obj_id=4) refs=2,4
+; if (!m) @ rbtree.c:205
+16: (15) if r8 == 0x0 goto pc+52      ; R8_w=ptr_node_data(ref_obj_id=4) refs=2,4
+17: (b7) r1 = 6                       ; R1_w=6 refs=2,4
+; m->data = 6; @ rbtree.c:208
+18: (7b) *(u64 *)(r8 +8) = r1         ; R1_w=6 R8_w=ptr_node_data(ref_obj_id=4) refs=2,4
+19: (b7) r1 = 5                       ; R1_w=5 refs=2,4
+; m->key = 5; @ rbtree.c:207
+20: (7b) *(u64 *)(r8 +0) = r1         ; R1_w=5 R8_w=ptr_node_data(ref_obj_id=4) refs=2,4
+; o = bpf_obj_new(typeof(*o)); @ rbtree.c:210
+21: (18) r1 = 0x11                    ; R1_w=17 refs=2,4
+23: (b7) r2 = 0                       ; R2_w=0 refs=2,4
+24: (85) call bpf_obj_new_impl#54651          ; R0=ptr_or_null_node_data(id=6,ref_obj_id=6) refs=2,4,6
+; if (!o) @ rbtree.c:211
+25: (15) if r0 == 0x0 goto pc+79      ; R0=ptr_node_data(ref_obj_id=6) refs=2,4,6
+26: (b7) r7 = 2                       ; R7_w=2 refs=2,4,6
+; o->data = 2; @ rbtree.c:214
+27: (7b) *(u64 *)(r0 +8) = r7         ; R0=ptr_node_data(ref_obj_id=6) R7_w=2 refs=2,4,6
+28: (b7) r1 = 1                       ; R1_w=1 refs=2,4,6
+; o->key = 1; @ rbtree.c:213
+29: (7b) *(u64 *)(r0 +0) = r1         ; R0=ptr_node_data(ref_obj_id=6) R1_w=1 refs=2,4,6
+; bpf_spin_lock(&glock); @ rbtree.c:216
+30: (18) r1 = 0xff434b28008e3de8      ; R1_w=map_value(map=.data.A,ks=4,vs=72,off=16) refs=2,4,6
+32: (bf) r9 = r0                      ; R0=ptr_node_data(ref_obj_id=6) R9_w=ptr_node_data(ref_obj_id=6) refs=2,4,6
+33: (85) call bpf_spin_lock#93        ; refs=2,4,6
+; bpf_rbtree_add(&groot, &n->node, less); @ rbtree.c:217
+34: (bf) r2 = r6                      ; R2_w=ptr_node_data(ref_obj_id=2) R6=ptr_node_data(ref_obj_id=2) refs=2,4,6
+35: (07) r2 += 16                     ; R2_w=ptr_node_data(ref_obj_id=2,off=16) refs=2,4,6
+36: (18) r1 = 0xff434b28008e3dd8      ; R1_w=map_value(map=.data.A,ks=4,vs=72) refs=2,4,6
+38: (18) r3 = 0x53                    ; R3_w=func() refs=2,4,6
+40: (b7) r4 = 0                       ; R4_w=0 refs=2,4,6
+41: (b7) r5 = 0                       ; R5=0 refs=2,4,6
+42: (85) call bpf_rbtree_add_impl#54894       ; R0_w=scalar() R6=ptr_node_data(non_own_ref) R7=2 R8=ptr_node_data(ref_obj_id=4) R9=ptr_node_data(ref_obj_id=6) R10=fp0 refs=4,6
+; bpf_rbtree_add(&groot, &m->node, less); @ rbtree.c:218
+43: (07) r8 += 16                     ; R8_w=ptr_node_data(ref_obj_id=4,off=16) refs=4,6
+44: (18) r1 = 0xff434b28008e3dd8      ; R1_w=map_value(map=.data.A,ks=4,vs=72) refs=4,6
+46: (bf) r2 = r8                      ; R2_w=ptr_node_data(ref_obj_id=4,off=16) R8_w=ptr_node_data(ref_obj_id=4,off=16) refs=4,6
+47: (18) r3 = 0x4a                    ; R3_w=func() refs=4,6
+49: (b7) r4 = 0                       ; R4_w=0 refs=4,6
+50: (b7) r5 = 0                       ; R5=0 refs=4,6
+51: (85) call bpf_rbtree_add_impl#54894       ; R0_w=scalar() R6=ptr_node_data(non_own_ref) R7=2 R8=ptr_node_data(non_own_ref,off=16) R9=ptr_node_data(ref_obj_id=6) R10=fp0 refs=6
+; bpf_rbtree_add(&groot, &o->node, less); @ rbtree.c:219
+52: (07) r9 += 16                     ; R9_w=ptr_node_data(ref_obj_id=6,off=16) refs=6
+53: (18) r1 = 0xff434b28008e3dd8      ; R1_w=map_value(map=.data.A,ks=4,vs=72) refs=6
+55: (bf) r2 = r9                      ; R2_w=ptr_node_data(ref_obj_id=6,off=16) R9_w=ptr_node_data(ref_obj_id=6,off=16) refs=6
+56: (18) r3 = 0x41                    ; R3_w=func() refs=6
+58: (b7) r4 = 0                       ; R4_w=0 refs=6
+59: (b7) r5 = 0                       ; R5=0 refs=6
+60: (85) call bpf_rbtree_add_impl#54894       ; R0_w=scalar() R6=ptr_node_data(non_own_ref) R7=2 R8=ptr_node_data(non_own_ref,off=16) R9=ptr_node_data(non_own_ref,off=16) R10=fp0
+; res = bpf_rbtree_first(&groot); @ rbtree.c:221
+61: (18) r1 = 0xff434b28008e3dd8      ; R1_w=map_value(map=.data.A,ks=4,vs=72)
+63: (85) call bpf_rbtree_first#54897          ; R0_w=ptr_or_null_node_data(id=7,non_own_ref,off=16)
+; if (!res) { @ rbtree.c:222
+64: (55) if r0 != 0x0 goto pc+6 71: R0=ptr_node_data(non_own_ref,off=16) R6=ptr_node_data(non_own_ref) R7=2 R8=ptr_node_data(non_own_ref,off=16) R9=ptr_node_data(non_own_ref,off=16) R10=fp0
+; first_data[0] = o->data; @ rbtree.c:228
+71: (79) r1 = *(u64 *)(r0 -8)         ; R0=ptr_node_data(non_own_ref,off=16) R1_w=scalar()
+72: (18) r2 = 0xff6f3b1a00e97010      ; R2_w=map_value(map=rbtree.data,ks=4,vs=32,off=16)
+74: (7b) *(u64 *)(r2 +0) = r1         ; R1_w=scalar() R2_w=map_value(map=rbtree.data,ks=4,vs=32,off=16)
+; res = bpf_rbtree_remove(&groot, &o->node); @ rbtree.c:230
+75: (18) r1 = 0xff434b28008e3dd8      ; R1_w=map_value(map=.data.A,ks=4,vs=72)
+77: (bf) r2 = r0                      ; R0=ptr_node_data(non_own_ref,off=16) R2_w=ptr_node_data(non_own_ref,off=16)
+78: (85) call bpf_rbtree_remove#54900         ; R0_w=ptr_or_null_node_data(id=9,ref_obj_id=9,off=16)
+79: (bf) r8 = r0                      ; R0_w=ptr_or_null_node_data(id=9,ref_obj_id=9,off=16) R8_w=ptr_or_null_node_data(id=9,ref_obj_id=9,off=16)
+; bpf_spin_unlock(&glock); @ rbtree.c:231
+80: (18) r1 = 0xff434b28008e3de8      ; R1_w=map_value(map=.data.A,ks=4,vs=72,off=16)
+82: (85) call bpf_spin_unlock#94      ; refs=9
+83: (b7) r7 = 5                       ; R7_w=5 refs=9
+; if (!res) @ rbtree.c:233
+84: (15) if r8 == 0x0 goto pc+26      ; R8=ptr_node_data(ref_obj_id=9,off=16) refs=9
+; removed_key = o->key; @ rbtree.c:237
+85: (79) r1 = *(u64 *)(r8 -16)        ; R1_w=scalar() R8=ptr_node_data(ref_obj_id=9,off=16) refs=9
+86: (18) r2 = 0xff6f3b1a00e97008      ; R2_w=map_value(map=rbtree.data,ks=4,vs=32,off=8) refs=9
+88: (7b) *(u64 *)(r2 +0) = r1         ; R1_w=scalar() R2_w=map_value(map=rbtree.data,ks=4,vs=32,off=8) refs=9
+; o = container_of(res, struct node_data, node); @ rbtree.c:236
+89: (07) r8 += -16                    ; R8_w=ptr_node_data(ref_obj_id=9) refs=9
+; bpf_obj_drop(o); @ rbtree.c:238
+90: (bf) r1 = r8                      ; R1_w=ptr_node_data(ref_obj_id=9) R8_w=ptr_node_data(ref_obj_id=9) refs=9
+91: (b7) r2 = 0                       ; R2_w=0 refs=9
+92: (85) call bpf_obj_drop_impl#54635         ;
+; bpf_spin_lock(&glock); @ rbtree.c:240
+93: (18) r1 = 0xff434b28008e3de8      ; R1_w=map_value(map=.data.A,ks=4,vs=72,off=16)
+95: (85) call bpf_spin_lock#93        ;
+; res = bpf_rbtree_first(&groot); @ rbtree.c:241
+96: (18) r1 = 0xff434b28008e3dd8      ; R1_w=map_value(map=.data.A,ks=4,vs=72)
+98: (85) call bpf_rbtree_first#54897          ; R0_w=ptr_or_null_node_data(id=10,non_own_ref,off=16)
+; if (!res) { @ rbtree.c:242
+99: (55) if r0 != 0x0 goto pc+13 113: R0_w=ptr_node_data(non_own_ref,off=16) R6=scalar() R7=5 R8=scalar() R9=scalar() R10=fp0
+; first_data[1] = o->data; @ rbtree.c:248
+113: (79) r1 = *(u64 *)(r0 -8)        ; R0_w=ptr_node_data(non_own_ref,off=16) R1_w=scalar()
+114: (18) r2 = 0xff6f3b1a00e97010     ; R2_w=map_value(map=rbtree.data,ks=4,vs=32,off=16)
+116: (7b) *(u64 *)(r2 +8) = r1        ; R1_w=scalar() R2_w=map_value(map=rbtree.data,ks=4,vs=32,off=16)
+; bpf_spin_unlock(&glock); @ rbtree.c:249
+117: (18) r1 = 0xff434b28008e3de8     ; R1_w=map_value(map=.data.A,ks=4,vs=72,off=16)
+119: (85) call bpf_spin_unlock#94     ;
+; return n->data; @ rbtree.c:251
+120: (79) r7 = *(u64 *)(r6 +8)
+R6 invalid mem access 'scalar'
+verification time 842 usec
+stack depth 0+0
+processed 94 insns (limit 1000000) max_states_per_insn 0 total_states 10 peak_states 10 mark_read 6
+`;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,3 +1,5 @@
+import { ParsedLine, ParsedLineType } from "./parser";
+
 export async function fetchLogFromUrl(url: string) {
   try {
     const response = await fetch(url);
@@ -22,7 +24,7 @@ export function getVisibleIdxRange(linesLen: number): {
   const formattedLogLines = document.getElementById("formatted-log-lines");
   const logContainer = document.getElementById("log-container");
   if (!formattedLogLines || !logContainer) {
-    return { min: 0, max: 0 };
+    return { min: 0, max: 0 }; // Throw here
   }
   const linesRect = formattedLogLines.getBoundingClientRect();
   const containerRect = logContainer.getBoundingClientRect();
@@ -39,13 +41,43 @@ export function getVisibleIdxRange(linesLen: number): {
   return { min, max };
 }
 
-export function scrollToLine(idx: number, linesLen: number) {
-  const logContainer = document.getElementById("log-container");
-  if (!logContainer) {
-    return;
-  }
+function scrollToLine(el: HTMLElement, idx: number, linesLen: number) {
   const { min, max } = getVisibleIdxRange(linesLen);
   const page = max - min + 1;
   const relativePosition = normalIdx(idx - page * 0.618, linesLen) / linesLen;
-  logContainer.scrollTop = relativePosition * logContainer.scrollHeight;
+  el.scrollTop = relativePosition * el.scrollHeight;
+}
+
+export function scrollToLogLine(idx: number, linesLen: number) {
+  const logContainer = document.getElementById("log-container");
+  if (!logContainer) {
+    throw new Error("Log line container is not in the DOM");
+  }
+  scrollToLine(logContainer, idx, linesLen);
+}
+
+export function scrollToCLine(idx: number, linesLen: number) {
+  const cSourceContainer = document.getElementById("c-source-container");
+  if (!cSourceContainer) {
+    // This won't exist if the container is collapsed
+    return;
+  }
+  scrollToLine(cSourceContainer, idx, linesLen);
+}
+
+export function siblingInsLine(
+  insLines: ParsedLine[],
+  idx: number,
+  delta: number,
+): number {
+  // if delta is 1 we are looking for the next instruction
+  // if delta is -1 we are looking for the previous instruction
+  const n = insLines.length;
+  for (let i = normalIdx(idx + delta, n); 0 <= i && i < n; i += delta) {
+    const line = insLines[i];
+    if (line.type === ParsedLineType.INSTRUCTION) {
+      return i;
+    }
+  }
+  return normalIdx(idx, n);
 }


### PR DESCRIPTION
Some notable things to call out:
- I removed the line numbers column for the instruction/main view because after we removed the source lines they seemed a bit useless and took up valuable horizontal space. Additionally, I removed the "go to line" input box.
- The C source view and the instruction view are now completely in sync. If you click on a line in one, it will highlight the associated line or lines in the other. 
- The keyboard up/down/page-up/page-down navigation uses the last line clicked to determine which view to navigate
- The c source view is collapsable (like the state panel)
- The c source view is stacked by file name