### PR TITLE
Ignore empty C source lines

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -24,6 +24,8 @@ const AddrSpaceCastSample2 = "75: (bf) r1 = addr_space_cast(r2, 0, 64)";
 const ConditionalPseudoMayGotoSample = "2984: (e5) may_goto pc+3";
 const ConditionalPseudoGotoOrNopSample = "2984: (e5) goto_or_nop pc+3";
 const CSourceLineSample = "; n->key = 3; @ rbtree.c:201";
+const CSourceLineEmptySample1 = "; @ foo.h:42";
+const CSourceLineEmptySample2 = "; int i = 0; @ foo.h:0";
 
 function expectBpfIns(line: ParsedLine): BpfInstruction {
   expect(line.type).toBe(ParsedLineType.INSTRUCTION);
@@ -152,6 +154,19 @@ describe("parser", () => {
       fileName: "rbtree.c",
       lineNum: 201,
       id: "rbtree.c:201",
+    });
+  });
+
+  it("ignores empty source lines", () => {
+    expect(parseLine(CSourceLineEmptySample1, 13)).toEqual({
+      type: ParsedLineType.UNRECOGNIZED,
+      idx: 13,
+      raw: CSourceLineEmptySample1,
+    });
+    expect(parseLine(CSourceLineEmptySample2, 31)).toEqual({
+      type: ParsedLineType.UNRECOGNIZED,
+      idx: 31,
+      raw: CSourceLineEmptySample2,
     });
   });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -772,13 +772,17 @@ export function getCLineId(fileName: string, lineNum: number): string {
 function parseCSourceLine(str: string, idx: number): CSourceLine | null {
   const { match } = consumeRegex(RE_C_SOURCE_LINE, str);
   if (!match) return null;
+  const content = match[1];
   const fileName = match[2];
   const lineNum = parseInt(match[3], 10);
+  if (!content || lineNum === 0) {
+    return null;
+  }
   return {
     type: ParsedLineType.C_SOURCE,
     idx,
     raw: str,
-    content: match[1],
+    content,
     fileName,
     lineNum,
     id: getCLineId(fileName, lineNum),


### PR DESCRIPTION
Sometimes verifier emits empty C source lines, for example:

;  @ filter_helpers.h:227

They don't contain useful information, and collecting them may lead to mostly empty C source view. Ignore such lines at the parsing level.