### PR TITLE
index.html: add app-input and app-example-input meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
       name="description"
       content="Visualizing Linux Kernel BPF verifier log to help BPF programmers with debugging verification failures"
     />
+    <meta name="app-input" link=""/>
+    <meta
+      name="app-example-input"
+      link="https://gist.githubusercontent.com/theihor/e0002c119414e6b40e2192bd7ced01b1/raw/866bcc155c2ce848dcd4bc7fd043a97f39a2d370/gistfile1.txt"
+    />
     <link rel="manifest" href="manifest.json" />
     <title>BPF Verifier Visualizer</title>
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -311,9 +311,19 @@ function App() {
     [loadInputText],
   );
 
+  function getServerInjectedInputLink(): string | null {
+    const appInput = document.querySelector('meta[name="app-input"]');
+    return appInput?.getAttribute("link") || null;
+  }
+
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const url = params.get("url");
+    // first, check for server injected link
+    // then for a query param
+    let url: string | null = getServerInjectedInputLink();
+    if (!url) {
+      const params = new URLSearchParams(window.location.search);
+      url = params.get("url");
+    }
     if (url) {
       fetchLogFromUrl(url).then((text) => {
         if (text) {

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -56,12 +56,6 @@ exports[`App renders the correct starting elements 1`] = `
           />
         </div>
         <a
-          href="/?url=https://gist.githubusercontent.com/theihor/e0002c119414e6b40e2192bd7ced01b1/raw/866bcc155c2ce848dcd4bc7fd043a97f39a2d370/gistfile1.txt"
-          id="example-link"
-        >
-          Load an example log
-        </a>
-        <a
           class="howto-link"
           href="https://github.com/theihor/bpfvv/blob/master/HOWTO.md"
           rel="noreferrer"
@@ -144,12 +138,6 @@ exports[`App renders the log visualizer when text is pasted 1`] = `
             type="file"
           />
         </div>
-        <a
-          href="/?url=https://gist.githubusercontent.com/theihor/e0002c119414e6b40e2192bd7ced01b1/raw/866bcc155c2ce848dcd4bc7fd043a97f39a2d370/gistfile1.txt"
-          id="example-link"
-        >
-          Load an example log
-        </a>
         <a
           class="howto-link"
           href="https://github.com/theihor/bpfvv/blob/master/HOWTO.md"
@@ -473,12 +461,6 @@ exports[`App renders the log visualizer when text is pasted 2`] = `
             type="file"
           />
         </div>
-        <a
-          href="/?url=https://gist.githubusercontent.com/theihor/e0002c119414e6b40e2192bd7ced01b1/raw/866bcc155c2ce848dcd4bc7fd043a97f39a2d370/gistfile1.txt"
-          id="example-link"
-        >
-          Load an example log
-        </a>
         <a
           class="howto-link"
           href="https://github.com/theihor/bpfvv/blob/master/HOWTO.md"

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -52,8 +52,6 @@ for (const helper of BPF_HELPERS_JSON.helpers) {
   bpfHelpersMap.set(helper.name, args);
 }
 
-const EXAMPLE_LOG_URL =
-  "https://gist.githubusercontent.com/theihor/e0002c119414e6b40e2192bd7ced01b1/raw/866bcc155c2ce848dcd4bc7fd043a97f39a2d370/gistfile1.txt";
 const RIGHT_ARROW = "->";
 
 function CallHtml({
@@ -153,14 +151,18 @@ function CallHtml({
 }
 
 export function Example() {
-  return (
-    <a
-      id="example-link"
-      href={`${window.location.pathname}?url=${EXAMPLE_LOG_URL}`}
-    >
-      Load an example log
-    </a>
-  );
+  const url = document
+    .querySelector('meta[name="app-example-input"]')
+    ?.getAttribute("link");
+  if (url) {
+    return (
+      <a id="example-link" href={`${window.location.pathname}?url=${url}`}>
+        Load an example log
+      </a>
+    );
+  } else {
+    return <></>;
+  }
 }
 
 function ExitInstruction({ frame }: { frame: number }) {


### PR DESCRIPTION
Add special meta tags to give the webserver an opportunity to pre-define the input log for the react app.

If app-input meta tag has a link attribute set, the app will attempt to load the verifier log from there.

The app-example-input meta tag provides a way to modify a link for "load example log" button.