### PR TITLE
Parse value expressions printed on separate lines

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -16,7 +16,7 @@ import {
 } from "./parser";
 
 const AluInstructionSample = "0: (b7) r2 = 1                        ; R2_w=1";
-const BPFStateExprSample = "; R2_w=1 R10=fp0 fp-24_w=1";
+const BPFStateExprSample = "R2_w=1 R10=fp0 fp-24_w=1";
 const MemoryWriteSample = "1: (7b) *(u64 *)(r10 -24) = r2" + BPFStateExprSample;
 const CallInstructionSample = "7: (85) call bpf_probe_read_user#112";
 const AddrSpaceCastSample1 =


### PR DESCRIPTION
Verifier in some cases may print information about known values
separately from the relevant instruciton, for example:

    100: (85) call bpf_ringbuf_reserve#131
    101: frame1: R0=ringbuf_mem_or_null(id=5,ref_obj_id=5,sz=196) refs=5
    101: (bf) r7 = r0                     ; frame1: R0=ringbuf_mem_or_null(id=5,ref_obj_id=5,sz=196) R7_w=ringbuf_mem_or_null(id=5,ref_obj_id=5,sz=196) refs=5

Note that second line contains state produced by instrcution at 100.

Implement parsing these messages and incorporating the information
from them in the computed array of BpfState objects.
