### PR TITLE
Handle bad c source lines

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -792,7 +792,10 @@ function CSourceFile({
   for (let i = range[0]; i < range[1]; ++i) {
     const sourceId = `${file}:${i}`;
     const sourceLine = cSourceMap.cSourceLines.get(sourceId);
-    if (!sourceLine) {
+    if (sourceLine?.lineNum === 0) {
+      continue;
+    }
+    if (!sourceLine || sourceLine.ignore) {
       if (!unknownStart) {
         unknownStart = i;
       }

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -155,19 +155,30 @@ describe("parser", () => {
       fileName: "rbtree.c",
       lineNum: 201,
       id: "rbtree.c:201",
+      ignore: false,
     });
   });
 
-  it("ignores empty source lines", () => {
+  it("marks empty source lines", () => {
     expect(parseLine(CSourceLineEmptySample1, 13)).toEqual({
-      type: ParsedLineType.UNRECOGNIZED,
+      type: ParsedLineType.C_SOURCE,
       idx: 13,
       raw: CSourceLineEmptySample1,
+      content: "",
+      fileName: "foo.h",
+      lineNum: 42,
+      id: "foo.h:42",
+      ignore: true,
     });
     expect(parseLine(CSourceLineEmptySample2, 31)).toEqual({
-      type: ParsedLineType.UNRECOGNIZED,
+      type: ParsedLineType.C_SOURCE,
       idx: 31,
       raw: CSourceLineEmptySample2,
+      content: "int i = 0;",
+      fileName: "foo.h",
+      lineNum: 0,
+      id: "foo.h:0",
+      ignore: true,
     });
   });
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -216,6 +216,7 @@ export type CSourceLine = {
   fileName: string;
   lineNum: number;
   id: string;
+  ignore: boolean;
 } & GenericParsedLine;
 
 export enum KnownMessageInfoType {
@@ -318,7 +319,7 @@ const RE_GOTO_OP = /^((?:may_)?goto|goto_or_nop) (pc[+-][0-9]+)/;
 const RE_FRAME_ID = /^frame([0-9]+): /;
 const RE_ADDR_SPACE_CAST =
   /^(r[0-9]) = addr_space_cast\((r[0-9]), ([0-9]+, [0-9]+)\)/;
-const RE_C_SOURCE_LINE = /^; (.*) @ ([a-zA-Z0-9_\-.]+):([0-9]+)/;
+const RE_C_SOURCE_LINE = /^;\s*(.*) @ ([a-zA-Z0-9_\-.]+):([0-9]+)/;
 
 const BPF_ALU_OPERATORS = [
   "s>>=",
@@ -797,9 +798,6 @@ function parseCSourceLine(str: string, idx: number): CSourceLine | null {
   const content = match[1];
   const fileName = match[2];
   const lineNum = parseInt(match[3], 10);
-  if (!content || lineNum === 0) {
-    return null;
-  }
   return {
     type: ParsedLineType.C_SOURCE,
     idx,
@@ -807,6 +805,7 @@ function parseCSourceLine(str: string, idx: number): CSourceLine | null {
     content,
     fileName,
     lineNum,
+    ignore: !content || lineNum === 0,
     id: getCLineId(fileName, lineNum),
   };
 }


### PR DESCRIPTION
Instead of ignoring lines like this:
`;  @ pyperf.h:0` they should be
treated as c-source lines in the main view
but filtered out in the c source view because
they don't provide any value.

Previously they showed up in the main view
when other c source lines did not.