### PR TITLE
Fix getMemSlotDependencies recursive call guard

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -415,7 +415,10 @@ export function getMemSlotDependencies(
 
       deps = getMemSlotDependencies(verifierLogState, prevDepIdx, memSlotId);
     }
-  } else if (nReads === 1 && depIdx !== bpfState.idx) {
+  } else if (
+    nReads === 1 &&
+    (depIdx !== bpfState.idx || depIns.reads[0] !== memSlotId)
+  ) {
     deps = getMemSlotDependencies(verifierLogState, depIdx, depIns.reads[0]);
   }
 


### PR DESCRIPTION
In 2d07fba a guard against infinite recursion was added for cases when dependency index equals to selected idx.

This turns out to be too conservative, blocking propagation for simple cases like:

  r7 += 150
  r2 = r7    # dependency tree would stop here
  r3 = r2

Fix this by checking the target memSlotId as well in the guard.