### PR TITLE
Indirect stack access evaluation

### DIFF
--- a/src/components.test.tsx
+++ b/src/components.test.tsx
@@ -104,7 +104,7 @@ describe("MemSlot", () => {
     );
     const op = createOp(OperandType.MEM, 15, -38, "MEM");
     op.memref = {
-      address_reg: "r2",
+      reg: "r2",
       offset: 0,
     };
     render(<MemSlot line={line} op={op} />);


### PR DESCRIPTION
Teach analyzer to evaluate indirect stack access when computing the
array of BpfState objects.

This allows to track stack loads and stores done through a register
other than r10. For example:

    *(u64 *)(r1 +0) = r8

If at this point r1 = fp-24, then the value of r8 is written there. So
far bpfvv only could detect this from verifier-provided value
changes. Now it actually checks for the value of r1 at the point of a
store, and can detect a write to fp-24 even if value expression is
absent from the log.

Closes #28 