### PR TITLE
analyzer.ts: fix dependencies through side effects

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -354,8 +354,8 @@ export const parseBpfStateExprs = (
   let frameId = 0;
   if (frame.match) {
     frameId = parseInt(frame.match[1], 10);
-    rest = frame.rest;
   }
+  rest = frame.rest;
 
   let exprs = [];
   while (rest.length > 0) {


### PR DESCRIPTION
Commit 2d07fba enhanced dependency tracking with information about
    value changes reported by the verifier. This has broken an assumption
    in `getMemSlotDependencies` that only one slot can be written by an
    instruction. With side effects, it can be many. This lead to incorrect
    dependency chain being displayed in some cases.
    
Fix this by distinguishing and additional case in `getMemSlotDependencies`, which now handles three:

- an actual update such as from `+=` instruction
- an actual write, which can be detected by checking `writes` set of a `BpfInstruction`
- a side effect, which can only be noticed via value change in the `BpfState` (this is the new case)