### PR TITLE
When a new log is loaded scroll to last ins

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -323,8 +323,22 @@ function App() {
     onGotoEnd,
   ]);
 
+  // When a new log is loaded go to the last instruction
   useEffect(() => {
-    onGotoEnd();
+    const visualIdx = logLineIdxToVisualIdx.get(verifierLogState.lastInsIdx);
+    if (visualIdx === undefined) {
+      return;
+    }
+    const clineId =
+      verifierLogState.cSourceMap.logLineToCLine.get(
+        verifierLogState.lastInsIdx,
+      ) || "";
+    setSelectedAndScroll(
+      verifierLogState.lastInsIdx,
+      "",
+      visualIdx,
+      cLineIdToVisualIdx.get(clineId) || 0,
+    );
   }, [verifierLogState]);
 
   const loadInputText = useCallback(


### PR DESCRIPTION
Instead of scrolling and selected the last
line which is usually junk, scroll to the
last ins which is right above the error msg.