### PR TITLE
Utilize react-window for the rendering log lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-window": "^2.1.1"
   },
   "scripts": {
     "start": "vite",

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -172,7 +172,11 @@ exports[`App renders the log visualizer when text is pasted 1`] = `
           </div>
           <div
             id="c-source-content"
-          />
+          >
+            <div
+              id="c-source-files"
+            />
+          </div>
         </div>
         <div
           class=""
@@ -212,55 +216,56 @@ exports[`App renders the log visualizer when text is pasted 1`] = `
             id="log-content"
           >
             <div
-              class="line-numbers"
-              id="line-numbers-pc"
+              role="list"
+              style="position: relative; max-height: 100%; flex-grow: 1; overflow-y: auto;"
             >
               <div
-                class="line-numbers-line"
-              >
-                314:
-              </div>
-            </div>
-            <div
-              id="dependency-arrows"
-            >
-              <div
-                class="dep-arrow"
-                id="dep-arrow-line-0"
-                line-id="0"
-              />
-            </div>
-            <div
-              id="formatted-log-lines"
-            >
-              <div
-                class="log-line normal-line selected-line"
+                class="flex items-center justify-between log-line selected-line normal-line"
                 id="line-0"
                 line-index="0"
+                style="position: absolute; left: 0px; transform: translateY(0px); height: 20px; width: 100%;"
               >
-                <span
-                  class="line-indent"
+                <div
+                  class="pc-number"
+                >
+                  314
+                </div>
+                <div
+                  class="dep-arrow"
+                  id="dep-arrow-line-0"
+                  line-id="0"
                 />
-                *(u8 *)(
-                <span
-                  class="mem-slot"
-                  data-id="r7"
-                  id="mem-slot-r7-line-0"
+                <div
+                  class="log-line-content"
                 >
-                  r7
-                </span>
-                 +1303)
-                 
-                =
-                 
-                <span
-                  class="mem-slot"
-                  data-id="r1"
-                  id="mem-slot-r1-line-0"
-                >
-                  r1
-                </span>
+                  <span
+                    class="line-indent"
+                  />
+                  *(u8 *)(
+                  <span
+                    class="mem-slot"
+                    data-id="r7"
+                    id="mem-slot-r7-line-0"
+                  >
+                    r7
+                  </span>
+                   +1303)
+                   
+                  =
+                   
+                  <span
+                    class="mem-slot"
+                    data-id="r1"
+                    id="mem-slot-r1-line-0"
+                  >
+                    r1
+                  </span>
+                </div>
               </div>
+              <div
+                aria-hidden="true"
+                style="height: 20px; width: 100%; z-index: -1;"
+              />
             </div>
           </div>
         </div>

--- a/src/components.test.tsx
+++ b/src/components.test.tsx
@@ -3,7 +3,7 @@
  */
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
-import { JmpInstruction, MemSlot } from "./components";
+import { JmpInstruction, LogLineState, MemSlot } from "./components";
 import {
   BpfJmpKind,
   BpfInstructionClass,
@@ -43,6 +43,14 @@ function createOp(
   };
 }
 
+function getEmptyLogLineState(): LogLineState {
+  return {
+    memSlotId: "",
+    line: 0,
+    cLine: "",
+  };
+}
+
 function dummyBpfState(frame: number = 0): BpfState {
   const state = new BpfState({});
   state.frame = frame;
@@ -59,7 +67,15 @@ describe("MemSlot", () => {
 
   it("renders raw line when op is undefined", () => {
     const line = createParsedLine("test raw line", 0);
-    render(<MemSlot line={line} op={undefined} state={dummyBpfState()} />);
+    render(
+      <MemSlot
+        line={line}
+        op={undefined}
+        state={dummyBpfState()}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
+      />,
+    );
     expect(screen.getByText("test raw line")).toBeInTheDocument();
   });
 
@@ -70,6 +86,8 @@ describe("MemSlot", () => {
         line={line}
         op={createOp(OperandType.UNKNOWN, 10, -5)}
         state={dummyBpfState()}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
       />,
     );
     // screen.debug()
@@ -83,6 +101,8 @@ describe("MemSlot", () => {
         line={line}
         op={createOp(OperandType.IMM, 10, -7)}
         state={dummyBpfState()}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
       />,
     );
     expect(screen.getByText("aw line")).toBeInTheDocument();
@@ -98,6 +118,8 @@ describe("MemSlot", () => {
         line={line}
         op={createOp(OperandType.REG, 2, -45, "r7")}
         state={dummyBpfState()}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
       />,
     );
     const divs = document.getElementsByTagName("div");
@@ -117,6 +139,8 @@ describe("MemSlot", () => {
         line={line}
         op={createOp(OperandType.FP, 16, -82, "fp-8")}
         state={dummyBpfState()}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
       />,
     );
     const divs = document.getElementsByTagName("div");
@@ -136,7 +160,15 @@ describe("MemSlot", () => {
       reg: "r2",
       offset: 0,
     };
-    render(<MemSlot line={line} op={op} state={dummyBpfState()} />);
+    render(
+      <MemSlot
+        line={line}
+        op={op}
+        state={dummyBpfState()}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
+      />,
+    );
     const divs = document.getElementsByTagName("div");
     expect(divs.length).toBe(1);
     expect(divs[0].innerHTML).toBe(
@@ -153,7 +185,15 @@ describe("MemSlot", () => {
     };
     const bpfState = dummyBpfState();
     bpfState.values.set("r1", { value: "fp-16", effect: Effect.WRITE });
-    render(<MemSlot line={line} op={op} state={bpfState} />);
+    render(
+      <MemSlot
+        line={line}
+        op={op}
+        state={bpfState}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
+      />,
+    );
     const divs = document.getElementsByTagName("div");
     expect(divs.length).toBe(1);
     expect(divs[0].innerHTML).toBe(
@@ -234,7 +274,15 @@ describe("JmpInstruction", () => {
     };
     const line = createLine(ins);
 
-    render(<JmpInstruction ins={ins} line={line} state={dummyBpfState(1)} />);
+    render(
+      <JmpInstruction
+        ins={ins}
+        line={line}
+        state={dummyBpfState(1)}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
+      />,
+    );
     const divs = document.getElementsByTagName("div");
     expect(divs.length).toBe(1);
     expect(divs[0].innerHTML).toBe("<b>} exit ; return to stack frame 1</b>");
@@ -244,7 +292,15 @@ describe("JmpInstruction", () => {
     const ins = createTargetJmpIns(BpfJmpCode.JA, BpfJmpKind.SUBPROGRAM_CALL);
     const line = createLine(ins);
 
-    render(<JmpInstruction ins={ins} line={line} state={dummyBpfState(1)} />);
+    render(
+      <JmpInstruction
+        ins={ins}
+        line={line}
+        state={dummyBpfState(1)}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
+      />,
+    );
     const divs = document.getElementsByTagName("div");
     expect(divs.length).toBe(1);
     expect(divs[0].innerHTML).toBe("<b>pc+3() { ; enter new stack frame 1</b>");
@@ -254,7 +310,15 @@ describe("JmpInstruction", () => {
     const ins = createTargetJmpIns(BpfJmpCode.JA, BpfJmpKind.HELPER_CALL);
     const line = createLine(ins);
 
-    render(<JmpInstruction ins={ins} line={line} state={dummyBpfState(1)} />);
+    render(
+      <JmpInstruction
+        ins={ins}
+        line={line}
+        state={dummyBpfState(1)}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
+      />,
+    );
     const divs = document.getElementsByTagName("div");
     expect(divs.length).toBe(1);
     expect(divs[0].innerHTML).toBe(
@@ -270,7 +334,15 @@ describe("JmpInstruction", () => {
     );
     const line = createLine(ins);
 
-    render(<JmpInstruction ins={ins} line={line} state={dummyBpfState(1)} />);
+    render(
+      <JmpInstruction
+        ins={ins}
+        line={line}
+        state={dummyBpfState(1)}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
+      />,
+    );
     const divs = document.getElementsByTagName("div");
     expect(divs.length).toBe(1);
     expect(divs[0].innerHTML).toBe("goto&nbsp;pc+3");
@@ -284,7 +356,15 @@ describe("JmpInstruction", () => {
     );
     const line = createLine(ins);
 
-    render(<JmpInstruction ins={ins} line={line} state={dummyBpfState(1)} />);
+    render(
+      <JmpInstruction
+        ins={ins}
+        line={line}
+        state={dummyBpfState(1)}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
+      />,
+    );
     const divs = document.getElementsByTagName("div");
     expect(divs.length).toBe(1);
     expect(divs[0].innerHTML).toBe("may_goto&nbsp;pc+3");
@@ -298,7 +378,15 @@ describe("JmpInstruction", () => {
     );
     const line = createLine(ins);
 
-    render(<JmpInstruction ins={ins} line={line} state={dummyBpfState(1)} />);
+    render(
+      <JmpInstruction
+        ins={ins}
+        line={line}
+        state={dummyBpfState(1)}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
+      />,
+    );
     const divs = document.getElementsByTagName("div");
     expect(divs.length).toBe(1);
     expect(divs[0].innerHTML).toBe("goto_or_nop&nbsp;pc+3");
@@ -324,7 +412,15 @@ describe("JmpInstruction", () => {
     };
     const line = createLine(ins);
 
-    render(<JmpInstruction ins={ins} line={line} state={dummyBpfState(1)} />);
+    render(
+      <JmpInstruction
+        ins={ins}
+        line={line}
+        state={dummyBpfState(1)}
+        memSlotDependencies={[]}
+        selectedState={getEmptyLogLineState()}
+      />,
+    );
     const divs = document.getElementsByTagName("div");
     expect(divs.length).toBe(1);
     expect(divs[0].innerHTML).toBe(
@@ -352,7 +448,15 @@ describe("JmpInstruction", () => {
       setCallArgValue(state, "r4", "");
       setCallArgValue(state, "r5", "");
 
-      render(<JmpInstruction ins={ins} line={line} state={state} />);
+      render(
+        <JmpInstruction
+          ins={ins}
+          line={line}
+          state={state}
+          memSlotDependencies={[]}
+          selectedState={getEmptyLogLineState()}
+        />,
+      );
       const divs = document.getElementsByTagName("div");
       expect(divs.length).toBe(1);
 
@@ -380,7 +484,15 @@ describe("JmpInstruction", () => {
       setCallArgValue(state, "r4", "scalar()");
       setCallArgValue(state, "r5", "");
 
-      render(<JmpInstruction ins={ins} line={line} state={state} />);
+      render(
+        <JmpInstruction
+          ins={ins}
+          line={line}
+          state={state}
+          memSlotDependencies={[]}
+          selectedState={getEmptyLogLineState()}
+        />,
+      );
       const divs = document.getElementsByTagName("div");
       expect(divs.length).toBe(1);
 
@@ -409,7 +521,15 @@ describe("JmpInstruction", () => {
       setCallArgValue(state, "r2", "buffer_ptr");
       setCallArgValue(state, "r3", "");
 
-      render(<JmpInstruction ins={ins} line={line} state={state} />);
+      render(
+        <JmpInstruction
+          ins={ins}
+          line={line}
+          state={state}
+          memSlotDependencies={[]}
+          selectedState={getEmptyLogLineState()}
+        />,
+      );
       const divs = document.getElementsByTagName("div");
       expect(divs.length).toBe(1);
 

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
   --primary-dark: rgba(4, 4, 4, 1);
   --mid-gray: rgb(212, 212, 220);
   --mid-gray-50: rgba(212, 212, 220, 0.5);
-  --mid-gray-20: rgba(212, 212, 220, 0.2);
+  --mid-gray-20: rgba(245, 245, 245, 1);
   --dark-blue: rgb(0, 73, 183);
   --light-blue: rgb(0, 221, 255);
   --light-blue-20: rgba(0, 221, 255, 0.2);
@@ -73,6 +73,7 @@ h1 {
   height: 40px;
   background-color: var(--mid-gray-20);
   font-family: "Roboto Mono", monospace;
+  z-index: 1;
 }
 
 .nav-arrow:hover {
@@ -220,12 +221,7 @@ h1 {
 }
 
 #log-content {
-  overflow-y: scroll;
   height: 100%;
-  display: flex;
-  flex-direction: row;
-  min-width: 0;
-  gap: 0;
 }
 
 .log-nav-button {
@@ -269,7 +265,22 @@ h1 {
   color: var(--primary-dark);
 }
 
-#formatted-log-lines,
+.pc-number {
+  color: var(--primary-dark);
+  background-color: var(--mid-gray-20);
+  border-right: 2px solid var(--mid-gray);
+  min-width: 50px;
+  line-height: 1.4;
+  text-align: right;
+  white-space: pre;
+  margin-right: 8px;
+  padding-right: 8px;
+}
+
+.selected-line .pc-number {
+  font-weight: bold;
+}
+
 .source-lines {
   background: white;
   padding: 10px;
@@ -342,6 +353,7 @@ h1 {
 
 .log-line {
   display: flex;
+  white-space: nowrap;
 }
 
 .line-indent {
@@ -425,6 +437,14 @@ h1 {
 
 .dep-arrow {
   position: relative;
+  line-height: 1.4;
+  text-align: right;
+  user-select: none;
+  min-width: 2em;
+  white-space: pre;
+  height: fit-content;
+  height: 20px;
+  color: #000;
 }
 
 .dep-end::before {

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -1,5 +1,6 @@
 export const SAMPLE_LOG_DATA_1 = `
-          0: (18) r1 = 0x11                     ; R1_w=17
+0: (18) r1 = 0x11                     ; R1_w=17
+; if (!n) @ rbtree.c:199
 2: (b7) r2 = 0                        ; R2_w=0
 3: (85) call bpf_obj_new_impl#54651   ; R0_w=ptr_or_null_node_data(id=2,ref_obj_id=2) refs=2
 4: (bf) r6 = r0                       ; R0_w=ptr_or_null_node_data(id=2,ref_obj_id=2) R6_w=ptr_or_null_node_data(id=2,ref_obj_id=2) refs=2
@@ -130,4 +131,9 @@ R6 invalid mem access 'scalar'
 verification time 842 usec
 stack depth 0+0
 processed 94 insns (limit 1000000) max_states_per_insn 0 total_states 10 peak_states 10 mark_read 6
+`;
+
+export const SAMPLE_LOG_DATA_ERORR = `120: (79) r7 = *(u64 *)(r6 +8)
+R6 invalid mem access 'scalar'
+verification time 842 usec
 `;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -70,8 +70,8 @@ export function getVisibleCSourceRange(linesLen: number): {
   min: number;
   max: number;
 } {
-  const csourceContent = document.getElementById("c-source-content");
-  const csourceContainer = document.getElementById("c-source-container");
+  const csourceContent = document.getElementById("c-source-files");
+  const csourceContainer = document.getElementById("c-source-content");
   if (!csourceContent || !csourceContainer) {
     // Don't throw the container might be collapsed
     return { min: 0, max: 0 };
@@ -92,22 +92,8 @@ function scrollToLine(
   el.scrollTop = relativePosition * el.scrollHeight;
 }
 
-export function scrollToLogLine(visualIdx: number, linesLen: number) {
-  const logContainer = document.getElementById("log-content");
-  if (!logContainer) {
-    throw new Error("Log line container is not in the DOM");
-  }
-  const logRange = getVisibleLogLineRange(linesLen);
-  if (
-    (visualIdx < logRange.min + 8 || visualIdx > logRange.max - 8) &&
-    !(visualIdx < 0 || visualIdx >= linesLen)
-  ) {
-    scrollToLine(logContainer, visualIdx, logRange.max, logRange.min, linesLen);
-  }
-}
-
 export function scrollToCLine(visualIdx: number, linesLen: number) {
-  const cSourceContainer = document.getElementById("c-source-container");
+  const cSourceContainer = document.getElementById("c-source-content");
   if (!cSourceContainer) {
     // This won't exist if the container is collapsed
     return;


### PR DESCRIPTION
This will allow us to handle very large verifier
logs and not affect performance.

This involved moving a lot of state back into
the individual react components instead of utilizing `useMemo` for side effects on the dom to
adjust css styles.

Issue:
- https://github.com/libbpf/bpfvv/issues/91