### PR TITLE
Fix issue with initial go-to-end

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1604,13 +1604,16 @@ export function MainContent({
       verifierLogState.cSourceMap.logLineToCLine.get(
         verifierLogState.lastInsIdx,
       ) || "";
-    setSelectedAndScroll(
-      verifierLogState.lastInsIdx,
-      "",
-      visualIdx,
-      cLineIdToVisualIdx.get(clineId) || 0,
-    );
-  }, [verifierLogState]);
+    setTimeout(function () {
+      setSelectedAndScroll(
+        verifierLogState.lastInsIdx,
+        "",
+        visualIdx,
+        cLineIdToVisualIdx.get(clineId) || 0,
+        "",
+      );
+    }, 500);
+  }, [verifierLogState, logListRef]);
 
   const depArrowState: DepArrowState = useMemo(() => {
     const arrowState = {


### PR DESCRIPTION
There seems to be a race condition with react-window rendering rows and when the scroll handler gets called so introduce a small delay.